### PR TITLE
Changed paths in buildsample/Build.AviationSample.cls to match repo layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ After setup, the data is available for use in various ways:
   purposes only and neither intended nor warranted to be accurate. (Courtesy: [National Transportation
   Safety Board](http://www.ntsb.gov))
   
-* Upon setup (see end), data is loaded from the `gbl/Aviation.xml` file into these
+* Upon setup (see end), data is loaded from the `gbl/Aviation.AircraftD.xml` file into these
   classes.
 
 * The `Aviation.Utils` class is a helper classes used by the repo setup routine (see end).

--- a/buildsample/Build.AviationSample.cls
+++ b/buildsample/Build.AviationSample.cls
@@ -57,7 +57,7 @@ ClassMethod run(stagingroot As %String = "", interactive As %Boolean = 0)
     }
 
     //load and compile classes ***************************
-    set dir=stagingroot_"/cls/" ;works on both Windows and Unix
+    set dir=stagingroot_"/src/cls/" ;works on both Windows and Unix
     if '##class(%File).DirectoryExists(dir) {
         if interactive {
             write !!, "Looking for "_dir
@@ -74,7 +74,7 @@ ClassMethod run(stagingroot As %String = "", interactive As %Boolean = 0)
     if interactive {
         write !, "Loading data..."
     }
-    set file=stagingroot_"/gbl/aviation.xml" ;works on both Windows and Unix
+    set file=stagingroot_"/gbl/Aviation.AircraftD.xml" ;works on both Windows and Unix
     if '##class(%File).Exists(file) {
         if interactive {
             write !!, "Looking for "_file


### PR DESCRIPTION
There are some mismatches in the Run() method of Build.AviationSample.cls between where the code was looking for certain files and the current layout of the repo (looking for cls/Aviation instead of src/cls/Aviation, looking for gbl/Aviation.xml instead of gbl/Aviation.AircraftD.xml) which lead to problems when doing the usual setup